### PR TITLE
#157589622 Allow managers to delete or deactivate trainers from a gym

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,10 @@ target/
 # IDE
 .idea/
 
-# External Libraries 
+# External Libraries
 wger/core/static/bower_components
 node_modules
 
 #Virtualenv folder
 venv-django/*
+/venv

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -109,7 +109,6 @@ def delete(request, user_pk=None):
             not request.user.has_perm('gym.manage_gym')
                 or request.user.userprofile.gym_id != user.userprofile.gym_id
                 or user.has_perm('gym.manage_gym')
-                or user.has_perm('gym.gym_trainer')
                 or user.has_perm('gym.manage_gyms')):
             return HttpResponseForbidden()
     else:

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -38,7 +38,7 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
 
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>


### PR DESCRIPTION
#### What does this PR do?
The PR enables the gym managers to deactivate or delete trainers from the Gym.

#### Description of Task to be completed?
Give rights to the gym managers to delete or deactivate trainers.
Enable gym member list of trainers to be a link for Managers to be able to manipulate the users, by either deleting or deactivating the trainers.

#### Any background context you want to provide?

It is important for the gym manager to have control over the trainers in the gym so as to update their status in case of absence.

#### What are the relevant pivotal tracker stories?
Story ID: #157589622
Story Link: https://www.pivotaltracker.com/story/show/157589622

#### Screenshots
![image](https://user-images.githubusercontent.com/32554603/41146841-5b676ea8-6b0d-11e8-82dc-1b7770f67720.png)

The screenshot shows a gym manager successfully deactivating a gym trainer.

![image](https://user-images.githubusercontent.com/32554603/41146932-aa4f4d38-6b0d-11e8-97b7-e02988bae8d8.png)

The screenshot shows a gym manager successfully deleting a gym trainer.